### PR TITLE
Implement PDF-first full text retrieval strategy

### DIFF
--- a/src/crawl_first/analysis.py
+++ b/src/crawl_first/analysis.py
@@ -577,8 +577,8 @@ def _try_doi_fetcher_pdf_url(doi: str, email: str) -> Optional[Dict[str, Any]]:
     return None
 
 
-def _convert_text_to_yaml(text: str, source: str) -> str:
-    """Convert extracted text to YAML format for better structure."""
+def _structure_text_as_yaml(text: str, source: str) -> str:
+    """Parse and structure extracted text into YAML format with section detection."""
 
     # Parse the text into structured data
     lines = text.strip().split("\n")
@@ -663,7 +663,7 @@ def _attempt_full_text_retrieval(
         result = _try_pmcid_text(pmcid)
         if result:
             # Convert to YAML format
-            result["text"] = _convert_text_to_yaml(result["text"], "pmcid_bioc")
+            result["text"] = _structure_text_as_yaml(result["text"], "pmcid_bioc")
             result["format"] = "yaml"
             attempts["pmcid_native_text"] = result
 
@@ -671,7 +671,7 @@ def _attempt_full_text_retrieval(
         result = _try_pmid_text(pmid)
         if result:
             # Convert to YAML format
-            result["text"] = _convert_text_to_yaml(result["text"], "pmid_bioc")
+            result["text"] = _structure_text_as_yaml(result["text"], "pmid_bioc")
             result["format"] = "yaml"
             attempts["pmid_native_text"] = result
 
@@ -679,7 +679,7 @@ def _attempt_full_text_retrieval(
         result = _try_doi_simple_text(doi)
         if result:
             # Convert to YAML format
-            result["text"] = _convert_text_to_yaml(result["text"], "doi_bioc")
+            result["text"] = _structure_text_as_yaml(result["text"], "doi_bioc")
             result["format"] = "yaml"
             attempts["doi_native_text"] = result
 

--- a/src/crawl_first/analysis.py
+++ b/src/crawl_first/analysis.py
@@ -684,7 +684,11 @@ def _attempt_full_text_retrieval(
             attempts["doi_native_text"] = result
 
     # AVOID: PDF extraction methods entirely
-    # No _try_doi_advanced_text or PDF text extraction
+    # PDF extraction methods are avoided due to performance concerns and reliability issues.
+    # Extracting text from PDFs can be computationally expensive and error-prone, especially
+    # when dealing with complex layouts or scanned documents. Instead, we prioritize
+    # structured data sources like BioC XML or metadata APIs to ensure more accurate and
+    # efficient text retrieval.
 
     return attempts
 

--- a/src/crawl_first/analysis.py
+++ b/src/crawl_first/analysis.py
@@ -601,7 +601,7 @@ def _structure_text_as_yaml(text: str, source: str) -> str:
             # Simple heuristic: lines that are short and end with certain patterns might be headers
             if len(line) < LINE_LENGTH_THRESHOLD and (
                 line.isupper()
-                or line.endswith((":",))
+                or line.endswith(":")
                 or line.startswith(
                     (
                         "Abstract",


### PR DESCRIPTION
- Add PDF URL discovery via Unpaywall and DOIFetcher APIs
- Implement three-tier priority system: PDF URLs > native text > avoid PDF extraction
- Add YAML conversion for native BioC XML text format
- Pass user email through to avoid hardcoded email issues
- Remove slow PDF text extraction methods entirely
- Add comprehensive type annotations and error handling

🤖 Generated with [Claude Code](https://claude.ai/code)

closes or works arround 
- #8 
- #9 

but long term fixes might have to be added to artl-mcp