### PR TITLE
Quick win: Increase geocoding timeout to prevent timeouts

### DIFF
--- a/src/crawl_first/cli.py
+++ b/src/crawl_first/cli.py
@@ -7,6 +7,7 @@ environmental, geospatial, weather, publication, and ontological data.
 """
 
 import random
+import re
 from pathlib import Path
 from typing import List, Optional
 

--- a/src/crawl_first/cli.py
+++ b/src/crawl_first/cli.py
@@ -7,7 +7,6 @@ environmental, geospatial, weather, publication, and ontological data.
 """
 
 import random
-import re
 from pathlib import Path
 from typing import List, Optional
 

--- a/src/crawl_first/geospatial.py
+++ b/src/crawl_first/geospatial.py
@@ -105,7 +105,7 @@ def geocode_location_name(location_name: str) -> Dict[str, Any]:
     if cached:
         return cached
 
-    geolocator = Nominatim(user_agent="biosample-analyzer/1.0")
+    geolocator = Nominatim(user_agent="biosample-analyzer/1.0", timeout=10)
 
     result: Dict[str, Any] = {
         "location_name": location_name,
@@ -166,7 +166,7 @@ def reverse_geocode(lat: float, lon: float) -> Dict[str, Any]:
     if cached:
         return cached
 
-    geolocator = Nominatim(user_agent="biosample-analyzer/1.0")
+    geolocator = Nominatim(user_agent="biosample-analyzer/1.0", timeout=10)
 
     result = {
         "coordinates": {"latitude": lat, "longitude": lon},


### PR DESCRIPTION
- Set Nominatim geocoder timeout from default 1s to 10s
- Addresses 4 timeout errors identified in log analysis
- Affects both geocode_location_name() and reverse_geocode() functions
- Should resolve "Read timed out" errors for complex location queries

Based on log analysis showing consistent 1-second timeout failures

🤖 Generated with [Claude Code](https://claude.ai/code)